### PR TITLE
Add emdash to allowed characters, remove spaces

### DIFF
--- a/chrip.js
+++ b/chrip.js
@@ -10,7 +10,7 @@ function sleep(ms) {
 }
 
 function filename(name) {
-    return name.replaceAll('&', 'and').replaceAll(':', ' -').replaceAll(/[^a-z0-9 ._-]+/ig, '');
+    return name.replaceAll('&', 'and').replaceAll(':', '-').replaceAll(/\s+/g, '_').replaceAll(/[^a-z0-9._-—]+/ig, '');
 }
 
 async function getCover(dirname, driver) {


### PR DESCRIPTION
I had an audiobook where removing emdash stuck two words together, so I added emdash to the list of allowed characters.  I also re-wrote things so that it wouldn't put spaces in filenames, and replaced them with underscores.