### PR TITLE
Add Chrome options for no-sandbox and disable-dev-shm-usage

### DIFF
--- a/chrip.js
+++ b/chrip.js
@@ -109,6 +109,8 @@ async function setStatus(text) {
     opt.setBinaryPath(chromePath);
     opt.addArguments("--disable-features=DisableLoadExtensionCommandLineSwitch");
     opt.addArguments("--load-extension=" + path.join(__dirname, "ext"));
+    opt.addArguments("--no-sandbox");
+    opt.addArguments("--disable-dev-shm-usage");
     driver = await new Builder().forBrowser(Browser.CHROME).setChromeOptions(opt).build()
     try {
         await login(driver)


### PR DESCRIPTION
Added options to disable sandbox and shared memory usage to avoid SessionNotCreated errors from Selenium when running on Linux. Solves #36.