### PR TITLE
Ease-of-use Improvements wrt. Player vs. Details

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 **.jpg
 **.txt
 /.browser-cache
+.user-data/

--- a/chrip.js
+++ b/chrip.js
@@ -26,7 +26,7 @@ function getResumeStatusMessage(existingFiles, count) {
             const chapterMatch = prevFile.match(/ - \d{4} - (.+)\.m4a$/);
             const prevChapterName = chapterMatch ? chapterMatch[1] : null;
             if (prevChapterName) {
-                return `Ready! Navigate to chapter after "${prevChapterName}" and hit play`;
+                return `Ready! Navigate to chapter after '${prevChapterName}' and hit play`;
             }
         }
     }
@@ -242,12 +242,12 @@ async function waitForPlayer() {
         const currentPage = await getCurrentPage()
         if (!currentPage) {
             console.warn("Unrecognized URL. Will wait 2 seconds and try again...")
-            sleep(20_000);
+            await sleep(2000);
             continue;
         }
 
         if (currentPage === "library") {
-            sleep(20_000);
+            await sleep(2000);
             continue;
         }
 
@@ -342,6 +342,22 @@ async function main() {
         .build();
 
     try {
+        // Ensure only one tab exists and navigate to homepage
+        const handles = await driver.getAllWindowHandles();
+        if (handles.length > 1) {
+            console.log(`Closing ${handles.length - 1} extra tab(s)...`);
+            // Keep the first tab, close the rest
+            for (let i = 1; i < handles.length; i++) {
+                await driver.switchTo().window(handles[i]);
+                await driver.close();
+            }
+            await driver.switchTo().window(handles[0]);
+        }
+
+        // Always navigate to homepage to start fresh
+        await driver.get('https://www.chirpbooks.com/home');
+        await sleep(1000);
+
         await login(driver)
 
         const listingData = await waitForPlayer();

--- a/chrip.js
+++ b/chrip.js
@@ -6,33 +6,10 @@ const { writeFile } = require('node:fs/promises')
 const fs = require('fs');
 const path = require('path');
 
-
 let driver;
 
 function sleep(ms) {
     return new Promise((resolve) => setTimeout(resolve, ms));
-}
-
-// Wait for and switch to a new window/tab that opens
-async function waitForAndSwitchToNewWindow(originalHandle, timeoutMs = 10000) {
-    const startTime = Date.now();
-
-    while (Date.now() - startTime < timeoutMs) {
-        const handles = await driver.getAllWindowHandles();
-
-        // Look for a new handle that wasn't the original
-        const newHandle = handles.find(h => h !== originalHandle);
-
-        if (newHandle) {
-            console.log('New window/tab detected, switching to it...');
-            await driver.switchTo().window(newHandle);
-            return true;
-        }
-
-        await sleep(500);
-    }
-
-    return false;
 }
 
 function filename(name) {
@@ -76,203 +53,32 @@ async function getAudiobookDataFromListing() {
     return null;
 }
 
-// Check if we're on a player page
-async function isPlayerPage() {
-    try {
-        const elements = await driver.findElements(By.id('webplayer'));
-        return elements.length > 0;
-    } catch (e) {
-        return false;
-    }
-}
-
-// Check if play button is visible and clickable
-// Supports: player page button, card play button overlay, book detail "Start Listening" button
-async function isPlayButtonVisible() {
-    try {
-        // Check for player page play button
-        const playerButtons = await driver.findElements(By.css('.play-pause'));
-        if (playerButtons.length > 0) return true;
-        
-        // Check for card play button overlay
-        const cardPlayButtons = await driver.findElements(By.css('[data-testid="cover-image-play-arrow"]'));
-        if (cardPlayButtons.length > 0) return true;
-        
-        // Check for book detail page "Start Listening" button
-        const startListeningButtons = await driver.findElements(By.css('[data-testid="play-audiobook-button"]'));
-        return startListeningButtons.length > 0;
-    } catch (e) {
-        return false;
-    }
-}
-
-// Click the play button
-async function clickPlayButton() {
-    try {
-        // Try player page play button first
-        const playerButtons = await driver.findElements(By.css('.play-pause'));
-        if (playerButtons.length > 0) {
-            await playerButtons[0].click();
-            console.log('Clicked player page play button');
-            return true;
-        }
-        
-        // Try card play button overlay
-        const cardPlayButtons = await driver.findElements(By.css('[data-testid="cover-image-play-arrow"]'));
-        if (cardPlayButtons.length > 0) {
-            await cardPlayButtons[0].click();
-            console.log('Clicked card play button overlay');
-            return true;
-        }
-        
-        // Try book detail page "Start Listening" button
-        const startListeningButtons = await driver.findElements(By.css('[data-testid="play-audiobook-button"]'));
-        if (startListeningButtons.length > 0) {
-            await startListeningButtons[0].click();
-            console.log('Clicked Start Listening button');
-            return true;
-        }
-        
-        console.log('Could not find play button to click');
-        return false;
-    } catch (e) {
-        console.log('Could not click play button:', e.message);
-        return false;
-    }
-}
-
 // Wait for play button to be clickable
-async function waitForPlayButton(timeoutMs = 30000) {
+async function waitForPlayButton(timeoutMs) {
     const startTime = Date.now();
 
     while (Date.now() - startTime < timeoutMs) {
-        if (await isPlayButtonVisible()) {
+        const playerButtons = await driver.findElements(By.css('.play-pause'));
+        if (playerButtons.length) {
             return true;
         }
+
         await sleep(500);
     }
 
     return false;
 }
 
-// Check if we're on a listing/book page
-async function isListingPage() {
-    try {
-        const elements = await driver.findElements(By.css('[data-audiobook]'));
-        return elements.length > 0;
-    } catch (e) {
-        return false;
-    }
-}
+const PLAYER_URL_EXPR = /\/player\/\d+/
+const LIBRARY_URL_EXPR = /\/library/
+const DETAILS_URL_EXPR = /\/audiobooks\/.+/
 
-// Check if we're on a book detail page (separate from player page)
-async function isBookDetailPage() {
+async function getCurrentPage() {
     const currentUrl = await driver.getCurrentUrl();
-    // Book detail pages have /audiobooks/ in URL but no webplayer
-    return currentUrl.includes('/audiobooks/') && !(await isPlayerPage());
-}
-
-// Navigate to player from listing page by clicking the book
-async function navigateToPlayerFromListing(listingData = null) {
-    console.log('On listing page, navigating to player...');
-
-    // Store original window handle to detect new tabs
-    const originalHandle = await driver.getWindowHandle();
-    console.log('Stored original window handle');
-
-    // Try clicking approach - prefer play button overlay, then cover, then card
-    let clickSucceeded = false;
-    
-    // First try clicking the play button overlay (opens player directly)
-    try {
-        const playButtonOverlay = await driver.findElement(By.css('[data-testid="cover-image-play-arrow"]'));
-        await playButtonOverlay.click();
-        console.log('Clicked play button overlay');
-        clickSucceeded = true;
-        
-        // Wait for player to open in new tab
-        console.log('Waiting for player to open in new tab...');
-        const newWindowOpened = await waitForAndSwitchToNewWindow(originalHandle, 5000);
-        
-        if (!newWindowOpened) {
-            console.log('No new tab detected, checking if player opened in same tab...');
-        }
-    } catch (e) {
-        console.log('Could not click play button overlay, trying cover/card...');
-    }
-    
-    // If play button didn't work, try clicking the cover or card
-    if (!clickSucceeded) {
-        const clickSelectors = [
-            { selector: By.css('[data-testid="cover-image-container"]'), name: 'cover container' },
-            { selector: By.css('[data-testid="user-audiobook-card"]'), name: 'audiobook card' },
-            { selector: By.className('cover-image'), name: 'cover image' }
-        ];
-
-        for (const { selector, name } of clickSelectors) {
-            try {
-                const element = await driver.findElement(selector);
-                await element.click();
-                console.log('Clicked ' + name + ' to navigate to player');
-                clickSucceeded = true;
-
-                // Wait for navigation - could be new tab or same tab
-                console.log('Waiting for navigation...');
-                await sleep(3000);
-                
-                // Check if we opened a new tab
-                const newWindowOpened = await waitForAndSwitchToNewWindow(originalHandle, 3000);
-                if (newWindowOpened) {
-                    console.log('New tab detected, switched to it');
-                } else {
-                    console.log('Navigation stayed in same tab');
-                }
-
-                break;
-            } catch (e) {
-                console.log('Could not click ' + name + ', trying next option...');
-            }
-        }
-    }
-
-    // If clicking failed and we have listing data with URL, use direct navigation
-    if (!clickSucceeded && listingData && listingData.url) {
-        try {
-            const baseUrl = 'https://www.chirpbooks.com';
-            const playerUrl = baseUrl + listingData.url;
-            console.log('Click navigation failed, using direct URL: ' + playerUrl);
-            await driver.get(playerUrl);
-        } catch (e) {
-            console.error('Failed to navigate using listing URL:', e.message);
-            throw new Error('Could not navigate to player page');
-        }
-    }
-
-    // Wait for navigation to complete
-    console.log('Waiting for page to load...');
-    await sleep(3000);
-
-    // Check if we're on book detail page (need to click play button)
-    if (await isBookDetailPage()) {
-        console.log('On book detail page, looking for play button...');
-        if (await waitForPlayButton(30000)) {
-            const playClicked = await clickPlayButton();
-            if (playClicked) {
-                console.log('Clicked play button on book detail page');
-                await sleep(3000);
-                // Wait for player to load in new tab
-                await waitForAndSwitchToNewWindow(await driver.getWindowHandle(), 5000);
-            }
-        }
-    }
-
-    // Wait for the player to be initialized
-    await driver.wait(async () => {
-        return await isPlayerPage();
-    }, 30000);
-
-    console.log('Player page loaded');
-    await sleep(2000);
+    if (PLAYER_URL_EXPR.test(currentUrl)) return "player"
+    if (LIBRARY_URL_EXPR.test(currentUrl)) return "library"
+    if (DETAILS_URL_EXPR.test(currentUrl)) return "audiobook"
+    return undefined
 }
 
 async function getCover(dirname, coverUrlFromListing = null) {
@@ -333,7 +139,18 @@ async function getCredits(creditsFromListing = null) {
 }
 
 async function login() {
+    // Wait for document ready state to be 'complete'
+    await driver.wait(async () => {
+        const readyState = await driver.executeScript('return document.readyState');
+        return readyState === 'complete';
+    }, 10000); // 10 second timeout
+
+    // If there was a valid previous session still, do nothing more
+    const currentUrl = await driver.getCurrentUrl();
+    if (currentUrl.endsWith("/home")) return;
+
     await driver.get('https://www.chirpbooks.com/users/sign_in')
+
     await driver.wait(until.titleContains('Sign'), 1000)
 
     await driver.executeScript('document.querySelector("h1").textContent="Please sign-in to continue script"');
@@ -342,40 +159,19 @@ async function login() {
     await sleep(1000)
 }
 
-function extractChTrckCookie(cookieBundle) {
-    // Split the cookie bundle into individual cookie strings
-    const cookies = cookieBundle.split('; ');
-    // Find the cookie string starting with "ch_trck="
-    const chTrckCookie = cookies.find(cookie => cookie.startsWith('ch_trck='));
-
-    if (chTrckCookie) {
-        // Extract the encoded value after "ch_trck="
-        const encodedValue = chTrckCookie.split('=')[1];
-
-        return encodedValue;
-    } else {
-        console.error(JSON.stringify(cookies));
-        throw new Error("Cannot find cookie");
-    }
-}
-
 async function resetToLibrary() {
+    await driver.get('https://www.chirpbooks.com/library');
 
-    let allTabs = await driver.getAllWindowHandles();
-    for (let tab of allTabs) {
-        await driver.switchTo().window(tab); // Switch to the current tab
-        break;
-    }
-
-    await driver.get('https://www.chirpbooks.com/library')
-    while ((await driver.getTitle()).includes("My Library")) {
+    while ((await getCurrentPage()) === "library") {
         await sleep(1000)
-        let allTabs = await driver.getAllWindowHandles();
+
+        const allTabs = await driver.getAllWindowHandles();
         for (let tab of allTabs) {
             await driver.switchTo().window(tab); // Switch to the current tab
             // Check matching criteria (replace with your actual conditions)
-            let url = await driver.getCurrentUrl();
-            if (url.includes('player')) { // Example: Matching by title
+            const url = await driver.getCurrentUrl();
+            const tabPage = await getCurrentPage()
+            if (tabPage === "player") { // Example: Matching by title
                 console.log("Found matching tab:", url);
                 break; // Exit loop if you only need to find one
             }
@@ -384,48 +180,48 @@ async function resetToLibrary() {
 }
 
 function insertStatusElement() {
-    // Target the main audiobook card container directly
-    const targetContainer = document.querySelector('[data-testid="user-audiobook-card"]');
+    // Target the main player container
+    const targetContainer = document.querySelector('.player-main-container');
 
     if (!targetContainer) {
-        console.error('STATUS: Could not find book info container');
-        console.error('Expected selector: [data-testid="user-audiobook-card"]');
-        console.warn('Page may have an unexpected layout. Try refreshing or manually clicking the book.');
-        return { success: false, error: 'DOM_MISMATCH', triedSelectors: ['[data-testid="user-audiobook-card"]'] };
+        console.warn("Failed to find player main container!");
+        return "fail";
     }
 
     // Remove existing status element if present
-    const existingStatus = document.getElementById('status');
+    const existingStatus = document.getElementById('chrip-status');
     if (existingStatus) {
         existingStatus.remove();
     }
 
-    // Create and insert new status element
+    // Create and insert new status element with wrapper around it for more awareness
+    const statusWrapper = document.createElement('div');
+    statusWrapper.style.cssText = "display: flex; margin: auto";
+
     const statusEl = document.createElement('h1');
-    statusEl.id = 'status';
-    statusEl.style.cssText = 'color: white; margin: 10px 0; font-size: 1.2em;';
-    statusEl.textContent = 'status: initializing...';
+    statusEl.id = 'chrip-status';
+    statusEl.style.color = 'white';
+    statusEl.style.margin = '10px 0';
+    statusEl.style.padding = '8px';
+    statusEl.style.fontSize = '1.5rem';
+    statusEl.style.border = '4px solid #e42251';
+    statusEl.style.borderRadius = '4px';
+    statusEl.textContent = '🐤.🪦 Initializing...';
 
-    targetContainer.appendChild(statusEl);
-    return true;
+    statusWrapper.appendChild(statusEl);
+    targetContainer.appendChild(statusWrapper);
+
+    return "success";
 }
-
-// Convert function to string for Selenium execution
-const insertStatusElementString = insertStatusElement.toString();
 
 async function setStatus(text) {
     try {
-        const result = await driver.executeScript(`
-            const el = document.getElementById('status');
-            if (el) {
-                el.textContent = "status: " + ${JSON.stringify(text)};
-                return true;
-            }
-            return false;
-        `);
-        if (!result) {
+        const statusEl = driver.findElement(By.id("chrip-status"))
+        if (!statusEl) {
             console.warn('Status element not found, logging to console only');
+            return
         }
+        await driver.executeScript(`arguments[0].textContent = "🐤.🪦 ${text}"`, statusEl)
         console.log(text);
     } catch (err) {
         console.warn('Failed to update status element:', err.message);
@@ -433,9 +229,90 @@ async function setStatus(text) {
     }
 }
 
+async function waitForPlayer() {
+    let listingData = null;
+
+    await resetToLibrary();
+
+    console.log("Waiting for you to navigate to a book...");
+    console.log("Please click on a book in your library to open it.");
+
+    while (true) {
+        // Wait for user to navigate to either a listing page or player page
+        const currentPage = await getCurrentPage()
+        if (!currentPage) {
+            console.warn("Unrecognized URL. Will wait 2 seconds and try again...")
+            sleep(20_000);
+            continue;
+        }
+
+        if (currentPage === "library") {
+            sleep(20_000);
+            continue;
+        }
+
+        if (currentPage === "player") {
+            console.log("Player loaded!");
+            return listingData;
+        }
+
+        listingData = getAudiobookDataFromListing();
+
+        try {
+            const startListeningButtons = await driver.findElements(By.linkText('Start Listening'));
+            if (startListeningButtons.length === 0) {
+                console.log('Could not find play button to click');
+                continue
+            }
+
+            await startListeningButtons[0].click();
+            console.log('Automatically launching player from details page...');
+
+            const originalHandle = await driver.getWindowHandle();
+
+            const startTime = Date.now();
+            while (Date.now() - startTime < 10_000) {
+                const handles = await driver.getAllWindowHandles();
+
+                // Look for a new handle that wasn't the original
+                const newHandle = handles.find(h => h !== originalHandle);
+
+                if (newHandle) {
+                    console.log('New window/tab detected, switching to it...');
+                    await driver.switchTo().window(newHandle);
+                    break;
+                }
+
+                await sleep(500);
+            }
+
+            return listingData;
+        } catch (e) {
+            console.log('Could not click play button:', e.message);
+        }
+    }
+}
+
+async function attemptInsertStatus() {
+    // Try to insert status element with retry logic
+    const maxAttempts = 3;
+
+    for (let attempts = 0; attempts < maxAttempts; attempts++) {
+        const success = await driver.executeScript(`return (${insertStatusElement.toString()})() === "success"`);
+
+        if (success) {
+            console.log('Status element inserted successfully');
+            await setStatus("! PLEASE WAIT !");
+            return;
+        }
+
+        console.warn(`Attempt ${attempts}/${maxAttempts}: Could not find status element container`);
+    }
+}
+
 async function main() {
 
-    console.log("Ensuring Chrome for Testing is installed.");
+    console.log("Ensuring Chrome for Testing is installed...");
     const { path: chromePath } = await install({
         browser: PuppeteerBrowser.CHROME,
         buildId: '142.0.7444.59',
@@ -448,325 +325,200 @@ async function main() {
         fs.mkdirSync(downloadDir);
     }
 
-    let opt = new chrome.Options();
+    const opt = new chrome.Options();
     opt.setBinaryPath(chromePath);
     opt.addArguments("--disable-features=DisableLoadExtensionCommandLineSwitch");
-    opt.addArguments("--load-extension=" + path.join(__dirname, "ext"));
+    opt.addArguments(`--user-data-dir=${path.join(__dirname, ".user-data")}`);
+    opt.addArguments(`--load-extension=${path.join(__dirname, "ext")}`);
+    opt.addArguments("--disable-infobars");
     opt.setUserPreferences({
         'download.default_directory': downloadDir,
         'download.prompt_for_download': false,
         'download.directory_upgrade': true,
     });
-    driver = await new Builder().forBrowser(Browser.CHROME).setChromeOptions(opt).build()
+    driver = new Builder()
+        .forBrowser(Browser.CHROME)
+        .setChromeOptions(opt)
+        .build();
+
     try {
         await login(driver)
 
-        while (true) {
-            await resetToLibrary()
+        const listingData = await waitForPlayer();
+
+        console.log("On player page - proceeding with download setup")
+
+        await attemptInsertStatus();
+
+        // Wait for player elements to be ready
+        driver.wait(until.elementLocated(By.css("#webplayer.initialized")), 60 * 1000)
+        await sleep(3000)
+
+        // Retrieve optional cookies with null checks
+        const cfBmCookieObj = await driver.manage().getCookie('__cf_bm');
+        const cfBmCookie = cfBmCookieObj ? cfBmCookieObj.value : null;
+        if (!cfBmCookie) {
+            console.log('__cf_bm cookie was not found and is being skipped');
+        }
+
+        const mjWpScrtCookieObj = await driver.manage().getCookie('mj_wp_scrt');
+        const mjWpScrtCookie = mjWpScrtCookieObj ? mjWpScrtCookieObj.value : null;
+        if (!mjWpScrtCookie) {
+            console.log('mj_wp_scrt cookie was not found and is being skipped');
+        }
 
 
-            console.log("Waiting for you to navigate to a book...");
-            console.log("Please click on a book in your library to open it.");
+        // Extract metadata - use listing data if available, otherwise fall back to DOM
+        if (listingData) {
+            console.log('Using metadata from listing page...');
+        }
 
-            // Wait for user to navigate to either a listing page or player page
-            let onCorrectPage = false;
-            let listingData = null;
+        credits = await getCredits(listingData);
 
-            while (!onCorrectPage) {
-                await sleep(2000);
+        // Try to get title from listing data first, then fall back to DOM
+        if (listingData && listingData.displayTitle) {
+            title = listingData.displayTitle;
+            console.log(`Title from listing: ${title}`);
+        } else {
+            title = await driver.findElement(By.className("book-title")).getText();
+        }
 
-                // Check if we're on player page
-                if (await isPlayerPage()) {
-                    console.log('Detected player page');
-                    onCorrectPage = true;
-                    break;
-                }
-
-                // Check if we're on book detail page (need to click play button)
-                if (await isBookDetailPage()) {
-                    console.log('Detected book detail page, looking for play button...');
-                    
-                    // Wait for and click play button on book detail page
-                    if (await waitForPlayButton(30000)) {
-                        const playClicked = await clickPlayButton();
-                        if (playClicked) {
-                            console.log('Clicked play button on book detail page');
-                            // Wait for player to load in new tab
-                            await sleep(3000);
-                            // Check if player page loaded
-                            if (await isPlayerPage()) {
-                                console.log('Player page loaded after clicking play');
-                                onCorrectPage = true;
-                                break;
-                            }
-                        }
-                    }
-                    console.warn('Could not click play button on book detail page, will retry...');
-                }
-
-                // Check if we're on listing page
-                if (await isListingPage()) {
-                    console.log('Detected listing page, extracting metadata...');
-                    listingData = await getAudiobookDataFromListing();
-                    if (listingData) {
-                        console.log(`Book: ${listingData.displayTitle} by ${listingData.displayAuthors}`);
-                    }
-                    // Navigate to player page
-                    await navigateToPlayerFromListing(listingData);
-                    onCorrectPage = true;
-                    break;
-                }
-
-                // Check if URL indicates we're on a player or book page
-                const currentUrl = await driver.getCurrentUrl();
-                if (currentUrl.includes('/audiobooks/') || currentUrl.includes('player')) {
-                    console.log('Detected potential book/player page via URL');
-                    await sleep(3000); // Give it time to fully load
-
-                    // Re-check page type after wait
-                    if (await isPlayerPage()) {
-                        console.log('Confirmed player page after wait');
-                        onCorrectPage = true;
-                        break;
-                    }
-                    if (await isBookDetailPage()) {
-                        console.log('Confirmed book detail page after wait, looking for play button...');
-                        if (await waitForPlayButton(30000)) {
-                            const playClicked = await clickPlayButton();
-                            if (playClicked) {
-                                console.log('Clicked play button on book detail page');
-                                await sleep(3000);
-                                if (await isPlayerPage()) {
-                                    console.log('Player page loaded after clicking play');
-                                    onCorrectPage = true;
-                                    break;
-                                }
-                            }
-                        }
-                    }
-                    if (await isListingPage()) {
-                        console.log('Confirmed listing page after wait');
-                        listingData = await getAudiobookDataFromListing();
-                        await navigateToPlayerFromListing(listingData);
-                        onCorrectPage = true;
-                        break;
-                    }
-                }
+        const dirname = filename(`${title} - ${credits}`);
+        fs.mkdir(dirname, (err) => {
+            if (err && err.code !== 'EEXIST') {
+                throw err
             }
+            console.log('Directory created successfully!');
+        });
 
-            console.log("On player page - proceeding with download setup")
+        // Pass cover URL from listing data if available
+        await getCover(dirname, listingData ? listingData.coverUrl : null);
 
-            // Try to insert status element with retry logic
-            let statusInserted = false;
-            let attempts = 0;
-            const maxAttempts = 3;
-
-            while (!statusInserted && attempts < maxAttempts) {
-                attempts++;
-                const result = await driver.executeScript('return ' + insertStatusElementString);
-
-                if (result === true) {
-                    statusInserted = true;
-                    console.log('Status element inserted successfully');
-                } else if (result && result.success === false) {
-                    console.warn(`Attempt ${attempts}/${maxAttempts}: Could not find status element container`);
-                    console.warn('Tried selectors:', result.triedSelectors.join(', '));
-
-                    if (attempts < maxAttempts) {
-                        console.log('Waiting 5 seconds before retry...');
-                        await sleep(5000);
-                    } else {
-                        console.error('Max attempts reached. Page may have unexpected layout.');
-                        console.log('You can:');
-                        console.log('  1. Navigate to the book manually in the browser');
-                        console.log('  2. Refresh the page and wait for it to load');
-                        console.log('  3. Press Ctrl+C to exit and restart the script');
-                        console.log('Press Enter in this terminal to retry, or Ctrl+C to exit...');
-                        await new Promise(resolve => process.stdin.once('data', resolve));
-                        attempts = 0; // Reset attempts for another try
-                    }
-                }
-            }
-
-            if (statusInserted) {
-                await setStatus("!PLEASE WAIT!");
-            }
-
-            // Wait for player elements to be ready
-            await driver.wait(until.elementLocated(By.css("#webplayer.initialized")), 60 * 1000)
-            await sleep(3000)
-
-
-            const bundle = await driver.executeScript('return document.cookie')
-            const chTrckCookie = extractChTrckCookie(bundle);
-
-            // Retrieve optional cookies with null checks
-            const cfBmCookieObj = await driver.manage().getCookie('__cf_bm');
-            const cfBmCookie = cfBmCookieObj ? cfBmCookieObj.value : null;
-            if (!cfBmCookie) {
-                console.log('__cf_bm cookie was not found and is being skipped');
-            }
-
-            const mjWpScrtCookieObj = await driver.manage().getCookie('mj_wp_scrt');
-            const mjWpScrtCookie = mjWpScrtCookieObj ? mjWpScrtCookieObj.value : null;
-            if (!mjWpScrtCookie) {
-                console.log('mj_wp_scrt cookie was not found and is being skipped');
-            }
-
-
-            // Extract metadata - use listing data if available, otherwise fall back to DOM
-            if (listingData) {
-                console.log('Using metadata from listing page...');
-            }
-
-            credits = await getCredits(listingData);
-
-            // Try to get title from listing data first, then fall back to DOM
-            if (listingData && listingData.displayTitle) {
-                title = listingData.displayTitle;
-                console.log(`Title from listing: ${title}`);
-            } else {
-                title = await driver.findElement(By.className("book-title")).getText();
-            }
-
-            const dirname = filename(`${title} - ${credits}`);
-            fs.mkdir(dirname, (err) => {
-                if (err && err.code !== 'EEXIST') {
-                    throw err
-                }
-                console.log('Directory created successfully!');
+        const existingFiles = fs.existsSync(dirname) ? fs.readdirSync(dirname) : [];
+        const trackNumbers = existingFiles
+            .filter(f => f.endsWith('.m4a'))
+            .map(f => {
+                const match = f.match(/- (\d{4}) -/);
+                return match ? parseInt(match[1], 10) : 0;
             });
+        let count = trackNumbers.length > 0 ? Math.max(...trackNumbers) + 1 : 1;
+        console.log(`Resuming from file ${count}`);
 
-            // Pass cover URL from listing data if available
-            await getCover(dirname, listingData ? listingData.coverUrl : null);
+        await setStatus(getResumeStatusMessage(existingFiles, count));
 
-            const existingFiles = fs.existsSync(dirname) ? fs.readdirSync(dirname) : [];
-            const trackNumbers = existingFiles
-                .filter(f => f.endsWith('.m4a'))
-                .map(f => {
-                    const match = f.match(/- (\d{4}) -/);
-                    return match ? parseInt(match[1], 10) : 0;
-                });
-            let count = trackNumbers.length > 0 ? Math.max(...trackNumbers) + 1 : 1;
-            console.log(`Resuming from file ${count}`);
+        const urls = [];
+        let moreChapters = true;
+        while (moreChapters) {
 
-            await setStatus(getResumeStatusMessage(existingFiles, count));
-            urls = [];
-            let moreChapters = true;
-            while (moreChapters) {
+            await sleep(1000)
+            await driver.wait(until.elementLocated(By.id('audioUrl')), 100000)
+            await setStatus("Downloading file " + count);
+            const element = await driver.findElement(By.id('audioUrl'))
+            const url = await element.getText()
+            if (urls.includes(url))
+                continue
 
-                await sleep(1000)
-                await driver.wait(until.elementLocated(By.id('audioUrl')), 100000)
-                await setStatus("Downloading file " + count);
-                const element = await driver.findElement(By.id('audioUrl'))
-                const url = await element.getText()
-                if (urls.includes(url))
-                    continue
+            urls.push(url)
 
-                urls.push(url)
+            // Pause playback while we work
+            const pause = await driver.findElement(By.className("play-pause playing"))
+            await pause.click();
 
-                // Pause playback while we work
-                const pause = await driver.findElement(By.className("play-pause playing"))
-                await pause.click();
+            const clearDownloadDir = () => {
+                const files = fs.readdirSync(downloadDir);
+                for (const file of files) {
+                    fs.unlinkSync(path.join(downloadDir, file));
+                }
+            };
 
-                const clearDownloadDir = () => {
+            const waitForDownload = async (timeoutMs = 60000) => {
+                const startTime = Date.now();
+                let lastSize = 0;
+                let stableCount = 0;
+
+                while (Date.now() - startTime < timeoutMs) {
                     const files = fs.readdirSync(downloadDir);
-                    for (const file of files) {
-                        fs.unlinkSync(path.join(downloadDir, file));
-                    }
-                };
+                    const downloading = files.filter(f => f.endsWith('.crdownload') || f.endsWith('.tmp'));
+                    const completed = files.filter(f => !f.endsWith('.crdownload') && !f.endsWith('.tmp'));
 
-                const waitForDownload = async (timeoutMs = 60000) => {
-                    const startTime = Date.now();
-                    let lastSize = 0;
-                    let stableCount = 0;
+                    if (completed.length > 0) {
+                        const filePath = path.join(downloadDir, completed[0]);
+                        const currentSize = fs.statSync(filePath).size;
 
-                    while (Date.now() - startTime < timeoutMs) {
-                        const files = fs.readdirSync(downloadDir);
-                        const downloading = files.filter(f => f.endsWith('.crdownload') || f.endsWith('.tmp'));
-                        const completed = files.filter(f => !f.endsWith('.crdownload') && !f.endsWith('.tmp'));
-
-                        if (completed.length > 0) {
-                            const filePath = path.join(downloadDir, completed[0]);
-                            const currentSize = fs.statSync(filePath).size;
-
-                            if (currentSize > 0 && currentSize === lastSize) {
-                                stableCount++;
-                                if (stableCount >= 3) {
-                                    return filePath;
-                                }
-                            } else {
-                                lastSize = currentSize;
-                                stableCount = 0;
+                        if (currentSize > 0 && currentSize === lastSize) {
+                            stableCount++;
+                            if (stableCount >= 3) {
+                                return filePath;
                             }
-                        } else if (downloading.length > 0) {
+                        } else {
+                            lastSize = currentSize;
                             stableCount = 0;
                         }
-
-                        await sleep(500);
+                    } else if (downloading.length > 0) {
+                        stableCount = 0;
                     }
-                    return null;
-                };
 
-                clearDownloadDir();
-
-
-                const originalWindow = await driver.getWindowHandle();
-                await driver.switchTo().newWindow('tab');
-                await driver.get(url);
-
-                const downloadedFile = await waitForDownload(60000);
-
-                if (!downloadedFile) {
-                    console.error('A download failed');
-                    console.error('Please rerun the script. Progress will be resumed from the last successful download.');
-                    await driver.close();
-                    await driver.switchTo().window(originalWindow);
-                    process.exit(1);
+                    await sleep(500);
                 }
+                return null;
+            };
 
+            clearDownloadDir();
+
+
+            const originalWindow = await driver.getWindowHandle();
+            await driver.switchTo().newWindow('tab');
+            await driver.get(url);
+
+            const downloadedFile = await waitForDownload(60000);
+
+            if (!downloadedFile) {
+                console.error('A download failed');
+                console.error('Please rerun the script. Progress will be resumed from the last successful download.');
                 await driver.close();
                 await driver.switchTo().window(originalWindow);
-                await sleep(500);
-
-                await setStatus("Waiting for 5 seconds to avoid rate limiting");
-
-                // Pause for 5 seconds to avoid rate limiting
-                await sleep(5000);
-
-
-                const audioBuffer = fs.readFileSync(downloadedFile);
-                console.log(`Downloaded ${path.basename(downloadedFile)}: ${audioBuffer.length} bytes`);
-
-
-                chapter = await driver.findElement(By.className("chapter")).getText()
-
-                let trackNum = count.toString().padStart(4, "0");
-                let name = filename(`${title} - ${trackNum} - ${chapter}.m4a`);
-                await writeFile(path.join(dirname, name), audioBuffer)
-                count++;
-
-                const btn = await driver.findElement(By.className("next-chapter"))
-                const enabled = await btn.isEnabled()
-                if (!enabled) {
-                    console.log('Download complete!');
-                    moreChapters = false;
-                    driver.close()
-                    break;
-                } else {
-                    await btn.click()
-                }
-
-                // Resume playback
-                const play = await driver.findElement(By.className("play-pause paused"))
-                await play.click();
+                process.exit(1);
             }
+
+            await driver.close();
+            await driver.switchTo().window(originalWindow);
+            await sleep(500);
+
+            await setStatus("Waiting for 5 seconds to avoid rate limiting");
+
+            // Pause for 5 seconds to avoid rate limiting
+            await sleep(5000);
+
+
+            const audioBuffer = fs.readFileSync(downloadedFile);
+            console.log(`Downloaded ${path.basename(downloadedFile)}: ${audioBuffer.length} bytes`);
+
+
+            chapter = await driver.findElement(By.className("chapter")).getText()
+
+            let trackNum = count.toString().padStart(4, "0");
+            let name = filename(`${title} - ${trackNum} - ${chapter}.m4a`);
+            await writeFile(path.join(dirname, name), audioBuffer)
+            count++;
+
+            const btn = await driver.findElement(By.className("next-chapter"))
+            const enabled = await btn.isEnabled()
+            if (!enabled) {
+                console.log('Download complete!');
+                moreChapters = false;
+                driver.close()
+                break;
+            } else {
+                await btn.click()
+            }
+
+            // Resume playback
+            const play = await driver.findElement(By.className("play-pause paused"))
+            await play.click();
         }
-    }
-    catch (error) {
+    } catch (error) {
         console.error(error);
-    }
-    finally {
+    } finally {
         if (driver) {
             await driver.quit()
         }

--- a/chrip.js
+++ b/chrip.js
@@ -126,7 +126,7 @@ async function resetToLibrary() {
 
 function insertStatusElement() {
     // Target the main player container
-    const targetContainer = document.querySelector('.player-main-container');
+    const targetContainer = document.querySelector('#webplayer > div.player-main-container > div.player-book-info > div.book-info');
 
     if (!targetContainer) {
         console.warn("Failed to find player main container!");
@@ -141,7 +141,7 @@ function insertStatusElement() {
 
     // Create and insert new status element with wrapper around it for more awareness
     const statusWrapper = document.createElement('div');
-    statusWrapper.style.cssText = "display: flex; margin: auto";
+    statusWrapper.style.cssText = "display: flex; justify-content: center";
 
     const statusEl = document.createElement('h1');
     statusEl.id = 'chrip-status';


### PR DESCRIPTION
I'm not sure if it's just my system or if Chirp's library and player changed within the last couple of months, but the script would crash every time I clicked into a book. I later noticed the current implementation worked when going directly to the player by clicking the play button. That wasn't immediately clear to me, which is what prompted these changes. Post-changes, it was able to correctly download and merge 6 10-16 hour audiobooks without any trouble for either method (clicking Play vs. clicking in title details and then having it automatically open the player).

Some changes were made to help with ease of reading and to make certain parts a bit more reliable, but the majority of the work was updating the script to handle the user clicking the title of the book and going to the book details page instead of directly into the player.

I also added the Chrome flag to allow sessions to carry across runs. This means you don't have to sign back in every time you relaunch the script.

I'm happy to make adjustments as needed, and there's likely a few changes that aren't necessary.

For the record, I utilized an AI to assist with diffing the DOM against the script's current expectations and then the subsequent changes. I've reviewed all changes manually afterwards and confirmed the downloads worked as expected, at least as best I could given that I had 60+ hours of audio to listen through :joy: 