### PR TITLE
Add random sleep timer between 5 and 36 seconds to fix rate limit issues

### DIFF
--- a/chrip.js
+++ b/chrip.js
@@ -13,6 +13,10 @@ function sleep(ms) {
     return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+function randomIntFromInterval(min, max) { // min and max included 
+    return Math.floor(Math.random() * (max - min + 1) + min);
+  }
+
 function filename(name) {
     return name.replaceAll('&', 'and').replaceAll(':', ' -').replaceAll(/[^a-z0-9 ._-]+/ig, '');
 }
@@ -270,10 +274,11 @@ async function setStatus(text) {
                 await driver.switchTo().window(originalWindow);
                 await sleep(500);
                 
-                await setStatus("Waiting for 5 seconds to avoid rate limiting");
+                const sleeptimer = randomIntFromInterval(5000, 100000);
+                await setStatus(`Waiting for ${sleeptimer / 1000} seconds to avoid rate limiting`);
 
-                // Pause for 5 seconds to avoid rate limiting
-                await sleep(5000);
+                // Pause for x seconds to avoid rate limiting
+                await sleep(sleeptimer);
                 
                 
                 const audioBuffer = fs.readFileSync(downloadedFile);

--- a/chrip.js
+++ b/chrip.js
@@ -274,10 +274,9 @@ async function setStatus(text) {
                 await driver.switchTo().window(originalWindow);
                 await sleep(500);
                 
-                const sleeptimer = randomIntFromInterval(5000, 100000);
+                // Set Randomized rate-limit backoff timer here
+                const sleeptimer = randomIntFromInterval(15000, 36000);
                 await setStatus(`Waiting for ${sleeptimer / 1000} seconds to avoid rate limiting`);
-
-                // Pause for x seconds to avoid rate limiting
                 await sleep(sleeptimer);
                 
                 


### PR DESCRIPTION
Added a randomIntFromInterval function to generate a number between 5000 and 100000 to correlate to a sleep timer for the rate limit backoff. (This is probably adjustable, was being very conservative with the top end)

I then created the sleeptimer variable above  the rate limit sleep function calling the random timer inside the loop, which would randomize the time between downloads.  This has proven very useful to keep 403's away, especially since some books do VERY SMALL chapters and the rapidity of requests at 5 second backoffs definitely triggers it.    

This does slow down how rapidly you can get your book, but it tames the number of times I've had to restart considerably.  Testing with one of these shorter chapter books, I was previously limited to about 25 downloads before I got 403'd.  